### PR TITLE
Implement TwoPair

### DIFF
--- a/lib/poker_hands/hand_rankings/two_pair.rb
+++ b/lib/poker_hands/hand_rankings/two_pair.rb
@@ -1,5 +1,9 @@
 class TwoPair
   def check(hand)
-    true
+    ranks_in_hand = hand.map(&:rank)
+
+    pairs = ranks_in_hand.find_all { |rank| ranks_in_hand.count(rank) > 1 }
+
+    pairs.length > 2
   end
 end

--- a/lib/poker_hands/hand_rankings/two_pair.rb
+++ b/lib/poker_hands/hand_rankings/two_pair.rb
@@ -2,8 +2,6 @@ class TwoPair
   def check(hand)
     ranks_in_hand = hand.map(&:rank)
 
-    pairs = ranks_in_hand.find_all { |rank| ranks_in_hand.count(rank) > 1 }
-
-    pairs.length > 2
+    ranks_in_hand.uniq.count { |rank| ranks_in_hand.count(rank) > 1 } == 2
   end
 end


### PR DESCRIPTION
TwoPair determines if a 5 card poker hand contains two pairs of cards.
We separate the pairs out of the poker hand into their own array
and check if the length of the array implies we have two pairs, thus
returning true if so and false otherwise.

I'm very open to how we can make TwoPair look nicer, ie. not having to to separate the pairs into an array, but also without tagging `.length > 2` onto the end of the `find_all` check.