### PR TITLE
Add spec for RoyalFlush

### DIFF
--- a/spec/poker_hands_spec.rb
+++ b/spec/poker_hands_spec.rb
@@ -2,3 +2,4 @@ RSpec.describe PokerHands do
   it "has a version number" do
     expect(PokerHands::VERSION).not_to be nil
   end
+end

--- a/spec/royal_flush_spec.rb
+++ b/spec/royal_flush_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe RoyalFlush do
+  describe '.check' do
+    subject { RoyalFlush.new.check(hand) }
+
+    context 'when hand is a RoyalFlush' do
+      let(:hand) do
+        [
+          Card.new('14', 'D'),
+          Card.new('13', 'D'),
+          Card.new('12', 'D'),
+          Card.new('11', 'D'),
+          Card.new('10', 'D')
+        ]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when hand is not a RoyalFlush' do
+      let(:hand) do
+        [Card.new('4', 'S'), 
+        Card.new('11', 'S'),
+        Card.new('8', 'S'),
+        Card.new('2', 'S'),
+        Card.new('9', 'S')
+      ]
+      end
+      
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
We test the RoyalFlush service object a Royal Flush poker hand and a
poker hand that is not a Royal Flush, expecting true or false
respectively.

Please provide suggestions or syntax to look into.