### PR TITLE
Add spec for Pair

### DIFF
--- a/lib/poker_hands/hand_rankings/pair.rb
+++ b/lib/poker_hands/hand_rankings/pair.rb
@@ -2,6 +2,6 @@ class Pair
   def check(hand)
     ranks_in_hand = hand.map(&:rank)
 
-    ranks_in_hand.uniq.count { |rank| ranks_in_hand.count(rank) > 1 } == 1
+    ranks_in_hand.uniq.count { |rank| ranks_in_hand.count(rank) > 1 } > 0
   end
 end

--- a/spec/pair_spec.rb
+++ b/spec/pair_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Pair do
+  describe '.check' do
+    subject { Pair.new.check(hand) }
+
+    context 'when hand is a Pair' do
+      let(:hand) do
+        [
+          Card.new('14', 'H'),
+          Card.new('14', 'D'),
+          Card.new('8', 'C'),
+          Card.new('4', 'S'),
+          Card.new('7', 'H')
+        ]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when hand is a TwoPair' do
+      let(:hand) do
+        [
+          Card.new('4', 'C'),
+          Card.new('4', 'S'),
+          Card.new('3', 'C'),
+          Card.new('3', 'D'),
+          Card.new('12', 'C')
+        ]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when hand is not a Pair' do
+      let(:hand) do
+        [
+          Card.new('4', 'S'), 
+          Card.new('11', 'S'),
+          Card.new('8', 'S'),
+          Card.new('2', 'S'),
+          Card.new('9', 'S')
+        ]
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
Check if the Pair service object returns true when given a hand
containing a pair. Also check that a hand with more than one pair
also returns true.

The Pair service object now returns true when given a hand with more
than one pair after noticing it didn't when this test was run.