### PR TITLE
Add spec for RoyalFlush

### DIFF
--- a/spec/royal_flush_spec.rb
+++ b/spec/royal_flush_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../lib/poker_hands/hand_rankings/royal_flush'
+require_relative '../lib/poker_hands/card'
+
+RSpec.describe PokerHands::RoyalFlush do
+  describe '.check' do
+    subject { PokerHands::RoyalFlush.new.check(hand) }
+
+    context 'when hand is a RoyalFlush' do
+      let(:hand) do
+        [
+          PokerHands::Card.new('14', 'D'),
+          PokerHands::Card.new('13', 'D'),
+          PokerHands::Card.new('12', 'D'),
+          PokerHands::Card.new('11', 'D'),
+          PokerHands::Card.new('10', 'D')
+        ]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when hand is not a RoyalFlush' do
+      let(:hand) do
+      [
+        PokerHands::Card.new('4', 'S'), 
+        PokerHands::Card.new('11', 'S'),
+        PokerHands::Card.new('8', 'S'),
+        PokerHands::Card.new('2', 'S'),
+        PokerHands::Card.new('9', 'S')
+      ]
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
We test the RoyalFlush service object a Royal Flush poker hand and a
poker hand that is not a Royal Flush, expecting true or false
respectively.