### PR TITLE
Change . prefix to # for instance methods

### DIFF
--- a/spec/flush_spec.rb
+++ b/spec/flush_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Flush do
-  describe '.check' do
+  describe '#check' do
     subject { Flush.new.check(hand) }
 
     context 'when hand is a Flush' do

--- a/spec/four_of_a_kind_spec.rb
+++ b/spec/four_of_a_kind_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe FourOfAKind do
-  describe '.check' do
+  describe '#check' do
     subject { FourOfAKind.new.check(hand) }
 
     context 'when hand is a FourOfAKind' do

--- a/spec/full_house_spec.rb
+++ b/spec/full_house_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe FullHouse do
-  describe '.check' do
+  describe '#check' do
     subject { FullHouse.new.check(hand) }
 
     context 'when hand is a FullHouse' do

--- a/spec/pair_spec.rb
+++ b/spec/pair_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Pair do
-  describe '.check' do
+  describe '#check' do
     subject { Pair.new.check(hand) }
 
     context 'when hand is a Pair' do

--- a/spec/royal_flush_spec.rb
+++ b/spec/royal_flush_spec.rb
@@ -2,7 +2,7 @@ require_relative '../lib/poker_hands/hand_rankings/royal_flush'
 require_relative '../lib/poker_hands/card'
 
 RSpec.describe PokerHands::RoyalFlush do
-  describe '.check' do
+  describe '#check' do
     subject { PokerHands::RoyalFlush.new.check(hand) }
 
     context 'when hand is a RoyalFlush' do

--- a/spec/straight_flush_spec.rb
+++ b/spec/straight_flush_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe StraightFlush do
-  describe '.check' do
+  describe '#check' do
     subject { StraightFlush.new.check(hand) }
 
     context 'when hand is a StraightFlush' do

--- a/spec/straight_spec.rb
+++ b/spec/straight_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Straight do
-  describe '.check' do
+  describe '#check' do
     subject { Straight.new.check(hand) }
 
     context 'when hand is a Straight' do

--- a/spec/three_of_a_kind_spec.rb
+++ b/spec/three_of_a_kind_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ThreeOfAKind do
-  describe '.check' do
+  describe '#check' do
     subject { ThreeOfAKind.new.check(hand) }
 
     context 'when hand is a ThreeOfAKind' do

--- a/spec/two_pair_spec.rb
+++ b/spec/two_pair_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe TwoPair do
-  describe '.check' do
+  describe '#check' do
     subject { TwoPair.new.check(hand) }
 
     context 'when hand is a TwoPair' do


### PR DESCRIPTION
Previously referencing the check instance method in the hand_rankings
files with the class method indicator '.' instead of '#' as they are
instance methods.