### PR TITLE
Implement StraightFlush tie scenario

### DIFF
--- a/lib/poker_hands/hand_rankings/find_straight_flush.rb
+++ b/lib/poker_hands/hand_rankings/find_straight_flush.rb
@@ -7,7 +7,8 @@ module PokerHands
       if FindFlush.new.call(hand).nil? || FindStraight.new.call(hand).nil?
         return nil
       end
-      Entities::StraightFlush.new(hand: hand)
+
+      Entities::StraightFlush.new(cards: hand)
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
@@ -5,8 +5,16 @@ module PokerHands
       attr_reader :cards, :strength
 
       def initialize(cards:)
-        @cards
+        @cards = cards.map(&:rank).reverse
         @strength = 9
+      end
+
+      def <=>(other_hand)
+        if (@straight <=> other_hand.straight) != 0
+          return @straight <=> other_hand.straight
+        else
+          return 'tie'
+        end
       end
     end
   end


### PR DESCRIPTION
When both poker hands are a StraightFlush we need to decide a winner.
We use the <=> operator to decide this because we can compare the
ranks of the StraightFlush hands element to element until one hand beats
the other.

The <=> comparison is not intended to be used between poker hands at
this point unless they are of the same Entity, to resolve ties.