### PR TITLE
Implement RoyalFlush tie scenario

### DIFF
--- a/lib/poker_hands/hand_rankings/find_royal_flush.rb
+++ b/lib/poker_hands/hand_rankings/find_royal_flush.rb
@@ -1,11 +1,12 @@
 require_relative 'hand_entities/royal_flush'
+require_relative 'find_flush'
 
 module PokerHands
   class FindRoyalFlush
     def call(hand)
       royal_flush_ranks = ['10', '11', '12', '13', '14']
       
-      if hand.any? { |card| card.suit != hand.first.suit}
+      if FindFlush.new.call(hand).nil?
         return nil
       end
 
@@ -15,7 +16,7 @@ module PokerHands
         return nil
       end
 
-      Entities::RoyalFlush.new(hand: hand)
+      Entities::RoyalFlush.new(cards: hand)
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/royal_flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/royal_flush.rb
@@ -5,8 +5,16 @@ module PokerHands
       attr_reader :cards, :strength
 
       def initialize(cards:)
-        @cards = cards
+        @cards = cards.map(&:rank)
         @strength = 10
+      end
+
+      def <=>(other_hand)
+        if (@cards <=> other_hand.cards) != 0
+          return @cards <=> other_hand.cards
+        else
+          return 'tie'
+        end
       end
     end
   end


### PR DESCRIPTION
While there can never be a RoyalFlush tie scenario in a real game of
poker, there can be two royal flush's drawn in this version.

When both poker hands are a RoyalFlush we need to decide a winner.
In this scenario we use the <=> to return a tie when both poker hands
are a RoyalFlush because that is the only outcome of two RoyalFlush
hands.

The <=> comparison is not intended to be used between poker hands at
this point unless they are of the same Entity, to resolve ties.