### PR TITLE
Print hand types to console

### DIFF
--- a/lib/poker_hands/compare_hands.rb
+++ b/lib/poker_hands/compare_hands.rb
@@ -9,14 +9,16 @@ module PokerHands
       hand1 = ClassifyHand.new.call(@hand1)
       hand2 = ClassifyHand.new.call(@hand2)
 
+      @hand_types = "Hand 1 is a #{hand1.type}. Hand 2 is a #{hand2.type}."
+      
       determine_winner(hand1, hand2)
     end
 
     def determine_winner(hand1, hand2)
       if hand1.strength > hand2.strength
-        return 'hand 1 wins'
+        return "#{@hand_types} Hand 1 wins"
       elsif hand1.strength < hand2.strength
-        return 'hand 2 wins'
+        return "#{@hand_types} Hand 2 wins"
       else
         return tie(hand1, hand2)
       end
@@ -24,11 +26,11 @@ module PokerHands
 
     def tie(hand1, hand2)
       if (hand1 <=> hand2) == 1
-        return 'hand 1 wins'
+        return "#{@hand_types} Hand 1 wins"
       elsif (hand1 <=> hand2) == -1
-        return 'hand 2 wins'
+        return "#{@hand_types} Hand 2 wins"
       else
-        return 'tie'
+        return "#{@hand_types} Tie"
       end
     end
   end

--- a/lib/poker_hands/game.rb
+++ b/lib/poker_hands/game.rb
@@ -9,11 +9,11 @@ module PokerHands
       @hand1 = deck.draw(5)
       @hand2 = deck.draw(5)
 
-      winner = CompareHands.new.call(@hand1, @hand2)
+      winning_message = CompareHands.new.call(@hand1, @hand2)
       
-      puts "Hand 1: #{@hand1.join(', ')}"
-      puts "Hand 2: #{@hand2.join(', ')}"
-      puts "\n#{winner}"
+      puts "Hand 1: [#{@hand1.join(', ')}]"
+      puts "Hand 2: [#{@hand2.join(', ')}]"
+      puts "\n#{winning_message}"
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/flush.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class Flush
       include Comparable
-      attr_reader :flush, :strength
+      attr_reader :flush, :strength, :type
 
       def initialize(flush:)
+        @type = 'flush'
         @flush = flush.map(&:rank).sort.reverse
         @strength = 6
       end

--- a/lib/poker_hands/hand_rankings/hand_entities/four_of_a_kind.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/four_of_a_kind.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class FourOfAKind
       include Comparable
-      attr_reader :quads, :other_card, :strength
+      attr_reader :quads, :other_card, :strength, :type
 
       def initialize(quads:, other_card:)
+        @type = 'four of a kind'
         @quads = quads.map(&:rank).uniq
         @other_card = other_card.map(&:rank)
         @strength = 8

--- a/lib/poker_hands/hand_rankings/hand_entities/full_house.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/full_house.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class FullHouse
       include Comparable
-      attr_reader :set, :pair, :strength
+      attr_reader :set, :pair, :strength, :type
 
       def initialize(set:, pair:)
+        @type = 'full house'
         @set = set.map(&:rank)
         @pair = pair.map(&:rank)
         @strength = 7

--- a/lib/poker_hands/hand_rankings/hand_entities/high_card.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/high_card.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class HighCard
       include Comparable
-      attr_reader :cards, :strength
+      attr_reader :cards, :strength, :type
 
       def initialize(cards:)
+        @type = 'high card'
         @cards = cards.map(&:rank).sort.reverse
         @strength = 1
       end

--- a/lib/poker_hands/hand_rankings/hand_entities/pair.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/pair.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class Pair
       include Comparable
-      attr_reader :pair, :other_cards, :strength
+      attr_reader :pair, :other_cards, :strength, :type
 
       def initialize(pair:, other_cards:)
+        @type = 'pair'
         @pair = pair[0].rank
         @other_cards = other_cards.map(&:rank).sort.reverse
         @strength = 2

--- a/lib/poker_hands/hand_rankings/hand_entities/royal_flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/royal_flush.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class RoyalFlush
       include Comparable
-      attr_reader :cards, :strength
+      attr_reader :cards, :strength, :type
 
       def initialize(cards:)
+        @type = 'royal flush'
         @cards = cards.map(&:rank)
         @strength = 10
       end

--- a/lib/poker_hands/hand_rankings/hand_entities/straight.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/straight.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class Straight
       include Comparable
-      attr_reader :straight, :strength
+      attr_reader :straight, :strength, :type
 
       def initialize(straight:)
+        @type = 'straight'
         @straight = straight.map(&:rank).reverse
         @strength = 5
       end

--- a/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class StraightFlush
       include Comparable
-      attr_reader :cards, :strength
+      attr_reader :cards, :strength, :type
 
       def initialize(cards:)
+        @type = 'straight flush'
         @cards = cards.map(&:rank).reverse
         @strength = 9
       end

--- a/lib/poker_hands/hand_rankings/hand_entities/three_of_a_kind.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/three_of_a_kind.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class ThreeOfAKind
       include Comparable
-      attr_reader :set, :other_cards, :strength
+      attr_reader :set, :other_cards, :strength, :type
 
       def initialize(set:, other_cards:)
+        @type = 'three of a kind'
         @set = set.map(&:rank)
         @other_cards = other_cards.map(&:rank).sort.reverse
         @strength = 4

--- a/lib/poker_hands/hand_rankings/hand_entities/two_pair.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/two_pair.rb
@@ -2,9 +2,10 @@ module PokerHands
   module Entities
     class TwoPair
       include Comparable
-      attr_reader :pairs, :other_card, :strength
+      attr_reader :pairs, :other_card, :strength, :type
 
       def initialize(pairs:, other_card:)
+        @type = 'two pair'
         @pairs = pairs.map(&:rank).sort.reverse
         @other_card = other_card.map(&:rank)
         @strength = 3


### PR DESCRIPTION
We print the hand types to the console so that we don't need to stare
at the poker hands to figure out which poker hand they are.