### PR TITLE
Spec for FindFlush and remove rank stripping

### DIFF
--- a/lib/poker_hands/hand_rankings/find_flush.rb
+++ b/lib/poker_hands/hand_rankings/find_flush.rb
@@ -7,7 +7,7 @@ module PokerHands
         return nil
       end
       
-      Entities::Flush.new(flush: hand)
+      Entities::Flush.new(cards: hand)
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/flush.rb
@@ -2,20 +2,20 @@ module PokerHands
   module Entities
     class Flush
       include Comparable
-      attr_reader :flush, :strength, :type
+      attr_reader :cards, :strength, :type
 
-      def initialize(flush:)
+      def initialize(cards:)
         @type = 'flush'
-        @flush = flush
+        @cards = cards
         @strength = 6
       end
 
       def <=>(other_hand)
-        flush = @flush.map(&:rank).sort.reverse
-        other_hand_flush = other_hand.flush.map(&:rank).sort.reverse
+        cards = @cards.map(&:rank).sort.reverse
+        other_hand_cards = other_hand.cards.map(&:rank).sort.reverse
 
-        if (flush <=> other_hand_flush) != 0
-          return flush <=> other_hand_flush
+        if (cards <=> other_hand_cards) != 0
+          return cards <=> other_hand_cards
         else
           return 'tie'
         end

--- a/spec/hand_rankings/find_flush_spec.rb
+++ b/spec/hand_rankings/find_flush_spec.rb
@@ -9,20 +9,33 @@ RSpec.describe PokerHands::FindFlush do
     context 'when hand is a Flush' do
       let(:hand) do
         [
-          PokerHands::Card.new('4', 'S'),
-          PokerHands::Card.new('11', 'S'),
-          PokerHands::Card.new('8', 'S'),
-          PokerHands::Card.new('2', 'S'),
-          PokerHands::Card.new('9', 'S')
+          PokerHands::Card.new(4, 'S'),
+          PokerHands::Card.new(11, 'S'),
+          PokerHands::Card.new(8, 'S'),
+          PokerHands::Card.new(2, 'S'),
+          PokerHands::Card.new(9, 'S')
         ]
       end
 
       it { is_expected.to be_an_instance_of(PokerHands::Entities::Flush) }
 
-      #it 'returns the expected cards in the flush' do
-      #  binding.pry
-        #expect(subject.flush).to 
-      #end
+      it 'returns the expected cards in the flush' do
+        expect(subject.flush).to be(hand)
+      end
+    end
+    
+    context 'when hand is not a Flush' do
+      let (:hand) do
+        [
+          PokerHands::Card.new(4, 'H'),
+          PokerHands::Card.new(11, 'S'),
+          PokerHands::Card.new(8, 'S'),
+          PokerHands::Card.new(2, 'D'),
+          PokerHands::Card.new(9, 'S')
+        ]
+      end
+
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/hand_rankings/find_flush_spec.rb
+++ b/spec/hand_rankings/find_flush_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PokerHands::FindFlush do
       it { is_expected.to be_an_instance_of(PokerHands::Entities::Flush) }
 
       it 'returns the expected cards in the flush' do
-        expect(subject.flush).to be(hand)
+        expect(subject.cards).to be(hand)
       end
     end
     


### PR DESCRIPTION
We need to verify that we are getting an instance of the `Flush` entity
because `FindFlush` returns that entity, which is used to determine the
winner if a hand contains a flush.

We need to verify the `:flush` attribute on the `Flush` entity because we
cannot perform comparisons during a tie without properly saving the
`Card` objects provided when a flush is identified.

We need to verify that `FindFlush` only returns a` Flush` entity when a
flush is found because misidentifying a poker hand as a flush would
result in inaccurate identification of a winner.