### PR TITLE
Spec for FindHighCard and remove rank stripping

### DIFF
--- a/lib/poker_hands/hand_rankings/hand_entities/high_card.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/high_card.rb
@@ -6,14 +6,17 @@ module PokerHands
 
       def initialize(cards:)
         @type = 'high card'
-        @cards = cards.map(&:rank).sort.reverse
+        @cards = cards
         @strength = 1
       end
 
       def <=>(other_hand)
-        if (@cards <=> other_hand.cards) != 0
-          return @cards <=> other_hand.cards
-        elsif (@cards <=> other_hand.cards) == 0
+        cards = @cards.map(&:rank).sort.reverse
+        other_hand_cards = other_hand.cards.map(&:rank).sort.reverse
+
+        if (cards <=> other_hand_cards) != 0
+          return cards <=> other_hand_cards
+        else
           return 'tie'
         end
       end

--- a/spec/hand_rankings/find_high_card_spec.rb
+++ b/spec/hand_rankings/find_high_card_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../lib/poker_hands/hand_rankings/find_high_card'
+require_relative '../../lib/poker_hands/card'
+require 'pry'
+
+RSpec.describe PokerHands::FindHighCard do
+  describe '#call' do
+    subject { PokerHands::FindHighCard.new.call(hand) }
+
+    context 'when hand is a HighCard' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(4, 'H'),
+          PokerHands::Card.new(11, 'S'),
+          PokerHands::Card.new(8, 'D'),
+          PokerHands::Card.new(2, 'S'),
+          PokerHands::Card.new(9, 'C')
+        ]
+      end
+
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::HighCard) }
+
+      it 'returns the expected cards in the high card' do
+        expect(subject.cards).to be(hand)
+      end
+    end
+  end
+end


### PR DESCRIPTION
No longer strip ranks out of a high card hand.

Spec written for FindHighCard