### PR TITLE
Spec for FindStraight and remove rank stripping

### DIFF
--- a/lib/poker_hands/hand_rankings/find_straight.rb
+++ b/lib/poker_hands/hand_rankings/find_straight.rb
@@ -9,7 +9,7 @@ module PokerHands
         return nil
       end
       
-      Entities::Straight.new(straight: hand)
+      Entities::Straight.new(cards: hand)
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/straight.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/straight.rb
@@ -2,16 +2,20 @@ module PokerHands
   module Entities
     class Straight
       include Comparable
-      attr_reader :straight, :strength, :type
+      attr_reader :cards, :strength, :type
 
-      def initialize(straight:)
+      def initialize(cards:)
         @type = 'straight'
-        @straight = straight.map(&:rank).reverse
+        @cards = cards
         @strength = 5
       end
+      
       def <=>(other_hand)
-        if (@straight <=> other_hand.straight) != 0
-          return @straight <=> other_hand.straight
+        cards = @cards.map(&:rank).reverse
+        other_hand_cards = other_hand.cards.map(&:rank).reverse
+
+        if (cards <=> other_hand_cards) != 0
+          return cards <=> other_hand_cards
         else
           return 'tie'
         end

--- a/spec/hand_rankings/find_straight_spec.rb
+++ b/spec/hand_rankings/find_straight_spec.rb
@@ -1,0 +1,41 @@
+require 'poker_hands/hand_rankings/find_three_of_a_kind'
+require 'poker_hands/card'
+require 'spec_helper'
+
+RSpec.describe PokerHands::FindStraight do
+  describe '#call' do
+    subject { PokerHands::FindStraight.new.call(hand) }
+
+    context 'when hand is a straight' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(5, 'D'),
+          PokerHands::Card.new(6, 'H'),
+          PokerHands::Card.new(7, 'S'),
+          PokerHands::Card.new(4, 'H'),
+          PokerHands::Card.new(3, 'S')
+        ]
+      end
+
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::Straight) }
+
+      it 'returns the expected cards in the hand' do
+        expect(subject.cards).to be(hand)
+      end
+
+      context 'when hand is not a straight' do
+        let(:hand) do
+          [
+            PokerHands::Card.new(4, 'H'),
+            PokerHands::Card.new(11, 'S'),
+            PokerHands::Card.new(8, 'S'),
+            PokerHands::Card.new(2, 'D'),
+            PokerHands::Card.new(9, 'S')
+          ]
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create the spec for FindStraight.

Remove rank stripping from the Straight entity so we can test properly.