### PR TITLE
Spec for FindFullHouse and remove rank stripping

### DIFF
--- a/lib/poker_hands/hand_rankings/find_full_house.rb
+++ b/lib/poker_hands/hand_rankings/find_full_house.rb
@@ -17,7 +17,7 @@ module PokerHands
       set = hand.select { |card| card.rank == set_rank }
       pair = hand.select { |card| card.rank != set_rank }
       
-      Entities::FullHouse.new(set: set, pair: pair)
+      Entities::FullHouse.new(cards: hand, set: set, pair: pair)
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/full_house.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/full_house.rb
@@ -2,20 +2,27 @@ module PokerHands
   module Entities
     class FullHouse
       include Comparable
-      attr_reader :set, :pair, :strength, :type
+      attr_reader :cards, :set, :pair, :strength, :type
 
-      def initialize(set:, pair:)
+      def initialize(cards:, set:, pair:)
         @type = 'full house'
-        @set = set.map(&:rank)
-        @pair = pair.map(&:rank)
+        @cards = cards
+        @set = set
+        @pair = pair
         @strength = 7
       end
       
       def <=>(other_hand)
-        if (@set <=> other_hand.set) != 0
-          return @set <=> other_hand.set
-        elsif (@pair <=> other_hand.pair) != 0
-          return @pair <=> other_hand.pair
+        set = @set.map(&:rank)
+        pair = @pair.map(&:rank)
+
+        other_hand_set = other_hand.set.map(&:rank)
+        other_hand_pair = other_hand.pair.map(&:rank)
+
+        if (set <=> other_hand_set) != 0
+          return set <=> other_hand_set
+        elsif (pair <=> other_hand_pair) != 0
+          return pair <=> other_hand_pair
         else
           return 'tie'
         end

--- a/spec/find_full_house_spec.rb
+++ b/spec/find_full_house_spec.rb
@@ -1,0 +1,48 @@
+require 'poker_hands/hand_rankings/find_full_house'
+require 'poker_hands/card'
+require 'spec_helper'
+
+RSpec.describe PokerHands::FindFullHouse do
+  describe '#call' do
+    subject { PokerHands::FindFullHouse.new.call(hand) }
+
+    context 'when hand is a full house' do
+      let(:set_cards) do
+        [
+          PokerHands::Card.new(11, 'D'), 
+          PokerHands::Card.new(11, 'H'),
+          PokerHands::Card.new(11, 'S')
+        ]
+      end
+
+      let(:pair_cards) do
+        [
+          PokerHands::Card.new(2, 'C'),
+          PokerHands::Card.new(2, 'H')
+        ]
+      end
+
+      let(:hand) { set_cards + pair_cards }
+
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::FullHouse) }
+
+      it 'returns the expected cards in the hand' do
+        expect(subject.cards).to be(hand)
+      end
+
+      context 'when hand is not a full house' do
+        let(:hand) do
+          [
+            PokerHands::Card.new(4, 'H'),
+            PokerHands::Card.new(11, 'S'),
+            PokerHands::Card.new(8, 'S'),
+            PokerHands::Card.new(2, 'D'),
+            PokerHands::Card.new(9, 'S')
+          ]
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Spec created for FindFullHouse.

Removed rank stripping from the FullHouse entity that didn't
allow us to interact with Card objects.