### PR TITLE
Spec for FindFourOfAKind and remove rank stripping

### DIFF
--- a/lib/poker_hands/hand_rankings/find_four_of_a_kind.rb
+++ b/lib/poker_hands/hand_rankings/find_four_of_a_kind.rb
@@ -16,7 +16,7 @@ module PokerHands
       quads = hand.select { |card| card.rank == quads_rank }
       other_card = hand.select { |card| card.rank != quads_rank }
 
-      Entities::FourOfAKind.new(quads: quads, other_card: other_card)
+      Entities::FourOfAKind.new(cards: hand, quads: quads, other_card: other_card)
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/four_of_a_kind.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/four_of_a_kind.rb
@@ -2,20 +2,27 @@ module PokerHands
   module Entities
     class FourOfAKind
       include Comparable
-      attr_reader :quads, :other_card, :strength, :type
+      attr_reader :cards, :quads, :other_card, :strength, :type
 
-      def initialize(quads:, other_card:)
+      def initialize(cards:, quads:, other_card:)
         @type = 'four of a kind'
-        @quads = quads.map(&:rank).uniq
-        @other_card = other_card.map(&:rank)
+        @cards = cards
+        @quads = quads
+        @other_card = other_card
         @strength = 8
       end
 
       def <=>(other_hand)
-        if (@quads <=> other_hand.quads) != 0
-          return @quads <=> other_hand.quads
-        elsif (@other_card <=> other_hand.other_card) != 0
-          return @other_card <=> other_hand.other_card
+        quads = @quads.map(&:rank).uniq
+        other_card = @other_card.map(&:rank)
+
+        other_hand_quads = other_hand.quads.map(&:rank).uniq
+        other_hand_card = other_hand.other_card.map(&:rank)
+
+        if (quads <=> other_hand_quads) != 0
+          return quads <=> other_hand_quads
+        elsif (other_card <=> other_hand_card) != 0
+          return other_card <=> other_hand_card
         else
           return 'tie'
         end

--- a/spec/hand_rankings/four_of_a_kind_spec.rb
+++ b/spec/hand_rankings/four_of_a_kind_spec.rb
@@ -1,0 +1,48 @@
+require 'poker_hands/hand_rankings/find_four_of_a_kind'
+require 'poker_hands/card'
+require 'spec_helper'
+
+RSpec.describe PokerHands::FindFourOfAKind do
+  describe '#call' do
+    subject { PokerHands::FindFourOfAKind.new.call(hand) }
+
+    context 'when hand is a four of a kind' do
+      let(:quad_cards) do
+        [
+          PokerHands::Card.new(11, 'D'), 
+          PokerHands::Card.new(11, 'H'),
+          PokerHands::Card.new(11, 'S'),
+          PokerHands::Card.new(11, 'C')
+        ]
+      end
+
+      let(:other_card) do
+        [
+          PokerHands::Card.new(2, 'H')
+        ]
+      end
+
+      let(:hand) { quad_cards + other_card }
+
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::FourOfAKind) }
+
+      it 'returns the expected cards in the hand' do
+        expect(subject.cards).to be(hand)
+      end
+
+      context 'when hand is not a four of a kind' do
+        let(:hand) do
+          [
+            PokerHands::Card.new(4, 'H'),
+            PokerHands::Card.new(11, 'S'),
+            PokerHands::Card.new(8, 'S'),
+            PokerHands::Card.new(2, 'D'),
+            PokerHands::Card.new(9, 'S')
+          ]
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Spec created for FindFourOfAKind.

Removed rank stripping from the FourOfAKind entity that didn't
allow us to interact with Card objects.