### PR TITLE
Spec for FindStraightFlush and remove rank stripping

### DIFF
--- a/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
@@ -6,13 +6,16 @@ module PokerHands
 
       def initialize(cards:)
         @type = 'straight flush'
-        @cards = cards.map(&:rank).reverse
+        @cards = cards
         @strength = 9
       end
 
       def <=>(other_hand)
-        if (@straight <=> other_hand.straight) != 0
-          return @straight <=> other_hand.straight
+        straight = @cards.map(&:rank).reverse
+        other_hand_straight = straight.map(&:rank).reverse
+        
+        if (straight <=> other_hand_straight) != 0
+          return straight <=> other_hand_straight
         else
           return 'tie'
         end

--- a/spec/find_straight_flush_spec.rb
+++ b/spec/find_straight_flush_spec.rb
@@ -1,0 +1,41 @@
+require 'poker_hands/hand_rankings/find_straight_flush'
+require 'poker_hands/card'
+require 'spec_helper'
+
+RSpec.describe PokerHands::FindStraightFlush do
+  describe '#call' do
+    subject { PokerHands::FindStraightFlush.new.call(hand) }
+
+    context 'when hand is a straight flush' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(4, 'H'),
+          PokerHands::Card.new(5, 'H'),
+          PokerHands::Card.new(8, 'H'),
+          PokerHands::Card.new(6, 'H'),
+          PokerHands::Card.new(7, 'H')
+        ]
+      end
+
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::StraightFlush) }
+
+      it 'returns the expected cards in the straight flush' do
+        expect(subject.cards).to be(hand)
+      end
+
+      context 'when hand is not a straight flush' do
+        let(:hand) do
+          [
+            PokerHands::Card.new(4, 'H'),
+            PokerHands::Card.new(11, 'S'),
+            PokerHands::Card.new(8, 'S'),
+            PokerHands::Card.new(2, 'D'),
+            PokerHands::Card.new(9, 'S')
+          ]
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Spec created for FindStraightFlush.

Removed rank stripping from the FindStraightFlush entity that didn't
allow us to interact with Card objects.