### PR TITLE
Spec for FindRoyalFlush and remove rank stripping

### DIFF
--- a/lib/poker_hands/hand_rankings/find_royal_flush.rb
+++ b/lib/poker_hands/hand_rankings/find_royal_flush.rb
@@ -4,7 +4,7 @@ require 'poker_hands/hand_rankings/find_flush'
 module PokerHands
   class FindRoyalFlush
     def call(hand)
-      royal_flush_ranks = ['10', '11', '12', '13', '14']
+      royal_flush_ranks = [10, 11, 12, 13, 14]
       
       if FindFlush.new.call(hand).nil?
         return nil

--- a/lib/poker_hands/hand_rankings/hand_entities/royal_flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/royal_flush.rb
@@ -6,13 +6,16 @@ module PokerHands
 
       def initialize(cards:)
         @type = 'royal flush'
-        @cards = cards.map(&:rank)
+        @cards = cards
         @strength = 10
       end
 
       def <=>(other_hand)
-        if (@cards <=> other_hand.cards) != 0
-          return @cards <=> other_hand.cards
+        cards = @cards.map(&:rank)
+        other_hand_cards = cards.map(&:rank)
+
+        if (cards <=> other_hand_cards) != 0
+          return cards <=> other_hand_cards
         else
           return 'tie'
         end

--- a/spec/hand_rankings/find_royal_flush_spec.rb
+++ b/spec/hand_rankings/find_royal_flush_spec.rb
@@ -1,0 +1,41 @@
+require 'poker_hands/hand_rankings/find_royal_flush'
+require 'poker_hands/card'
+require 'spec_helper'
+
+RSpec.describe PokerHands::FindRoyalFlush do
+  describe '#call' do
+    subject { PokerHands::FindRoyalFlush.new.call(hand) }
+
+    context 'when hand is a royal flush' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(13, 'H'),
+          PokerHands::Card.new(14, 'H'),
+          PokerHands::Card.new(12, 'H'),
+          PokerHands::Card.new(10, 'H'),
+          PokerHands::Card.new(11, 'H')
+        ]
+      end
+
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::RoyalFlush) }
+
+      it 'returns the expected cards in the royal flush' do
+        expect(subject.cards).to be(hand)
+      end
+
+      context 'when hand is not a royal flush' do
+        let(:hand) do
+          [
+            PokerHands::Card.new(4, 'H'),
+            PokerHands::Card.new(11, 'S'),
+            PokerHands::Card.new(8, 'S'),
+            PokerHands::Card.new(2, 'D'),
+            PokerHands::Card.new(9, 'S')
+          ]
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Spec created for FindRoyalFlush.

Removed rank stripping from the FindRoyalFlush entity that didn't
allow us to interact with Card objects.