### PR TITLE
Add test for Straight high_card attribute

### DIFF
--- a/lib/poker_hands/hand_rankings/find_straight.rb
+++ b/lib/poker_hands/hand_rankings/find_straight.rb
@@ -3,10 +3,10 @@ require 'poker_hands/hand_rankings/hand_entities/straight'
 module PokerHands
   class FindStraight
     def call(hand)
-      hand.sort_by! { |card| card.rank }
+      sorted_hand = hand.sort_by { |card| card.rank }
 
-      if hand[-1].rank == 14 && hand[-2].rank == 5
-        wheel = hand.clone
+      if sorted_hand[-1].rank == 14 && sorted_hand[-2].rank == 5
+        wheel = sorted_hand.clone
         wheel.pop
 
         high_card = wheel.last
@@ -16,11 +16,11 @@ module PokerHands
         end
       end
 
-      if !hand.each_cons(2).all? { |card, next_card| next_card.rank == card.rank + 1 }
+      if !sorted_hand.each_cons(2).all? { |card, next_card| next_card.rank == card.rank + 1 }
         return nil
       end
 
-      high_card = hand.last
+      high_card = sorted_hand.last
       
       Entities::Straight.new(cards: hand, high_card: high_card)
     end

--- a/spec/hand_rankings/find_straight_spec.rb
+++ b/spec/hand_rankings/find_straight_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe PokerHands::FindStraight do
   describe '#call' do
     subject { PokerHands::FindStraight.new.call(hand) }
 
+    let(:hand) do
+      [
+        PokerHands::Card.new(5, 'D'),
+        PokerHands::Card.new(6, 'H'),
+        PokerHands::Card.new(7, 'S'),
+        PokerHands::Card.new(4, 'H'),
+        PokerHands::Card.new(3, 'S')
+      ]
+    end
+    let(:high_card) { hand[2] }
+
+    it 'returns the expected cards in the hand' do
+      expect(subject.cards).to be(hand)
+    end
+
+    it 'returns the expected high card in the hand' do
+      expect(subject.high_card).to be(high_card)
+    end
+
     context 'when hand is a straight' do
       let(:hand) do
         [
@@ -18,24 +37,34 @@ RSpec.describe PokerHands::FindStraight do
       end
 
       it { is_expected.to be_an_instance_of(PokerHands::Entities::Straight) }
+    end
 
-      it 'returns the expected cards in the hand' do
-        expect(subject.cards).to be(hand)
+    context 'when hand is a wheel straight' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(14, 'D'),
+          PokerHands::Card.new(2, 'H'),
+          PokerHands::Card.new(4, 'S'),
+          PokerHands::Card.new(3, 'H'),
+          PokerHands::Card.new(5, 'S')
+        ]
       end
 
-      context 'when hand is not a straight' do
-        let(:hand) do
-          [
-            PokerHands::Card.new(4, 'H'),
-            PokerHands::Card.new(11, 'S'),
-            PokerHands::Card.new(8, 'S'),
-            PokerHands::Card.new(2, 'D'),
-            PokerHands::Card.new(9, 'S')
-          ]
-        end
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::Straight) }
+    end
 
-        it { is_expected.to be_nil }
+    context 'when hand is not a straight' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(4, 'H'),
+          PokerHands::Card.new(11, 'S'),
+          PokerHands::Card.new(8, 'S'),
+          PokerHands::Card.new(2, 'D'),
+          PokerHands::Card.new(9, 'S')
+        ]
       end
+
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
Test to ensure that our logic to determine the high card in a straight
is correct.

This brought up the issue of sorting a poker hand in place, where a line
in find_straight.rb was doing such. Removed this to ensure that our
test passes.