### PR TITLE
Spec for StraightFlush

### DIFF
--- a/lib/poker_hands/hand_rankings/find_straight_flush.rb
+++ b/lib/poker_hands/hand_rankings/find_straight_flush.rb
@@ -8,7 +8,14 @@ module PokerHands
         return nil
       end
 
-      Entities::StraightFlush.new(cards: hand)
+      sorted_hand = hand.sort_by { |card| card.rank }
+      if sorted_hand[-1].rank == 14 && sorted_hand[-2].rank == 5
+        high_card = sorted_hand[-2]
+      else
+        high_card = sorted_hand.last
+      end
+      
+      Entities::StraightFlush.new(cards: hand, high_card: high_card)
     end
   end
 end

--- a/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
+++ b/lib/poker_hands/hand_rankings/hand_entities/straight_flush.rb
@@ -2,20 +2,21 @@ module PokerHands
   module Entities
     class StraightFlush
       include Comparable
-      attr_reader :cards, :strength, :type
+      attr_reader :cards, :high_card, :strength, :type
 
-      def initialize(cards:)
+      def initialize(cards:, high_card:)
         @type = 'straight flush'
         @cards = cards
+        @high_card = high_card
         @strength = 9
       end
 
       def <=>(other_hand)
-        straight = @cards.map(&:rank).reverse
-        other_hand_straight = straight.map(&:rank).reverse
-        
-        if (straight <=> other_hand_straight) != 0
-          return straight <=> other_hand_straight
+        high_card = @high_card.rank
+        other_hand_high_card = other_hand.high_card.rank
+
+        if (high_card <=> other_hand_high_card) != 0
+          return high_card <=> other_hand_high_card
         else
           return 'tie'
         end

--- a/spec/hand_rankings/find_straight_flush_spec.rb
+++ b/spec/hand_rankings/find_straight_flush_spec.rb
@@ -5,37 +5,65 @@ require 'spec_helper'
 RSpec.describe PokerHands::FindStraightFlush do
   describe '#call' do
     subject { PokerHands::FindStraightFlush.new.call(hand) }
+    let(:hand) do
+      [
+        PokerHands::Card.new(4, 'H'),
+        PokerHands::Card.new(5, 'H'),
+        PokerHands::Card.new(8, 'H'),
+        PokerHands::Card.new(6, 'H'),
+        PokerHands::Card.new(7, 'H')
+      ]
+    end
+    let(:high_card) { hand[2] }
+
+    it 'returns the expected cards in the hand' do
+      expect(subject.cards).to be(hand)
+    end
+
+    it 'returns the expected high card in the hand' do
+      expect(subject.high_card).to be(high_card)
+    end
 
     context 'when hand is a straight flush' do
       let(:hand) do
         [
-          PokerHands::Card.new(4, 'H'),
-          PokerHands::Card.new(5, 'H'),
-          PokerHands::Card.new(8, 'H'),
-          PokerHands::Card.new(6, 'H'),
-          PokerHands::Card.new(7, 'H')
+          PokerHands::Card.new(5, 'D'),
+          PokerHands::Card.new(6, 'D'),
+          PokerHands::Card.new(7, 'D'),
+          PokerHands::Card.new(4, 'D'),
+          PokerHands::Card.new(3, 'D')
         ]
       end
 
       it { is_expected.to be_an_instance_of(PokerHands::Entities::StraightFlush) }
+    end
 
-      it 'returns the expected cards in the straight flush' do
-        expect(subject.cards).to be(hand)
+    context 'when hand is a wheel straight flush' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(14, 'D'),
+          PokerHands::Card.new(2, 'D'),
+          PokerHands::Card.new(4, 'D'),
+          PokerHands::Card.new(3, 'D'),
+          PokerHands::Card.new(5, 'D')
+        ]
       end
 
-      context 'when hand is not a straight flush' do
-        let(:hand) do
-          [
-            PokerHands::Card.new(4, 'H'),
-            PokerHands::Card.new(11, 'S'),
-            PokerHands::Card.new(8, 'S'),
-            PokerHands::Card.new(2, 'D'),
-            PokerHands::Card.new(9, 'S')
-          ]
-        end
+      it { is_expected.to be_an_instance_of(PokerHands::Entities::StraightFlush) }
+    end
 
-        it { is_expected.to be_nil }
+    context 'when hand is not a straight flush' do
+      let(:hand) do
+        [
+          PokerHands::Card.new(4, 'H'),
+          PokerHands::Card.new(11, 'S'),
+          PokerHands::Card.new(8, 'S'),
+          PokerHands::Card.new(2, 'D'),
+          PokerHands::Card.new(9, 'S')
+        ]
       end
+
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/hand_rankings/hand_entities/straight_flush_spec.rb
+++ b/spec/hand_rankings/hand_entities/straight_flush_spec.rb
@@ -1,0 +1,167 @@
+require 'poker_hands/hand_rankings/hand_entities/straight_flush'
+require 'poker_hands/card'
+require 'spec_helper'
+
+
+RSpec.describe PokerHands::Entities::StraightFlush do
+  context 'a StraightFlush entity' do
+    subject do
+      PokerHands::Entities::StraightFlush.new(
+        cards: hand,
+        high_card: high_card
+      )
+    end
+
+    let(:hand) do
+      [
+        PokerHands::Card.new(10, 'H'),
+        PokerHands::Card.new(11, 'H'),
+        PokerHands::Card.new(8, 'H'),
+        PokerHands::Card.new(9, 'H'),
+        PokerHands::Card.new(7, 'H')
+      ]
+    end
+    let(:high_card) { hand[1] }
+
+    it 'returns the expected cards' do
+      expect(subject.cards).to be(hand)
+    end
+
+    it 'returns the expected high card' do
+      expect(subject.high_card).to be(high_card)
+    end
+
+    it "is type 'straight flush'" do
+      expect(subject.type).to eq('straight flush')
+    end
+
+    it 'has strength 9' do
+      expect(subject.strength).to be 9
+    end
+  end
+
+  describe '#<=>' do
+    context 'hand 1 wins with the better straight flush' do
+      let(:straight_flush_1) do
+        [
+          PokerHands::Card.new(10, 'H'),
+          PokerHands::Card.new(11, 'H'),
+          PokerHands::Card.new(8, 'H'),
+          PokerHands::Card.new(9, 'H'),
+          PokerHands::Card.new(7, 'H')
+        ]
+      end
+      let(:high_card_1) { straight_flush_1[1] }
+
+      let(:straight_flush_2) do
+        [
+          PokerHands::Card.new(3, 'C'),
+          PokerHands::Card.new(5, 'C'),
+          PokerHands::Card.new(4, 'C'),
+          PokerHands::Card.new(7, 'C'),
+          PokerHands::Card.new(6, 'C')
+        ]
+      end
+      let(:high_card_2) { straight_flush_1[3] }
+
+      let(:hand_1) do
+        PokerHands::Entities::StraightFlush.new(
+          cards: straight_flush_1,
+          high_card: high_card_1
+        )
+      end
+      let(:hand_2) do
+        PokerHands::Entities::StraightFlush.new(
+          cards: straight_flush_2,
+          high_card: high_card_2
+        )
+      end
+        
+      it 'returns hand 1 as the winner' do
+        expect(hand_1 <=> hand_2).to be 1
+      end
+    end
+
+    context 'hand 2 wins with the better straight flush' do
+      let(:straight_flush_1) do
+        [
+          PokerHands::Card.new(3, 'C'),
+          PokerHands::Card.new(5, 'C'),
+          PokerHands::Card.new(4, 'C'),
+          PokerHands::Card.new(7, 'C'),
+          PokerHands::Card.new(6, 'C')
+        ]
+      end
+      let(:high_card_1) { straight_flush_1[3] }
+
+      let(:straight_flush_2) do
+        [
+          PokerHands::Card.new(10, 'H'),
+          PokerHands::Card.new(11, 'H'),
+          PokerHands::Card.new(8, 'H'),
+          PokerHands::Card.new(9, 'H'),
+          PokerHands::Card.new(7, 'H')
+        ]
+      end
+      let(:high_card_2) { straight_flush_2[1] }
+
+      let(:hand_1) do
+        PokerHands::Entities::StraightFlush.new(
+          cards: straight_flush_1,
+          high_card: high_card_1
+        )
+      end
+      let(:hand_2) do
+        PokerHands::Entities::StraightFlush.new(
+          cards: straight_flush_2,
+          high_card: high_card_2
+        )
+      end
+
+      it 'returns hand 2 as the winner' do
+        expect(hand_1 <=> hand_2).to be -1
+      end
+    end
+
+    context 'the hands are a tie' do
+      let(:straight_flush_1) do
+        [
+          PokerHands::Card.new(3, 'H'),
+          PokerHands::Card.new(5, 'H'),
+          PokerHands::Card.new(4, 'H'),
+          PokerHands::Card.new(7, 'H'),
+          PokerHands::Card.new(6, 'H')
+        ]
+      end
+      let(:high_card_1) { straight_flush_1[3] }
+
+      let(:straight_flush_2) do
+        [
+          PokerHands::Card.new(3, 'C'),
+          PokerHands::Card.new(5, 'C'),
+          PokerHands::Card.new(4, 'C'),
+          PokerHands::Card.new(7, 'C'),
+          PokerHands::Card.new(6, 'C')
+        ]
+      end
+      let(:high_card_2) { straight_flush_2[3] }
+
+      let(:hand_1) do
+        PokerHands::Entities::StraightFlush.new(
+          cards: straight_flush_1,
+          high_card: high_card_1
+        )
+      end
+      let(:hand_2) do
+        PokerHands::Entities::StraightFlush.new(
+          cards: straight_flush_2,
+          high_card: high_card_2
+        )
+      end
+
+      it 'returns a tie' do
+        expect(hand_1 <=> hand_2).to eq('tie')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Spec for StraightFlush.

Add wheel straight flush logic to FindStraightFlush.

Add wheel and high card tests to the FindStraightFlush spec.

Requires #80 to be merged.