### PR TITLE
Add Spec for Deck and BuildCards

### DIFF
--- a/lib/poker_hands/build_cards.rb
+++ b/lib/poker_hands/build_cards.rb
@@ -1,0 +1,18 @@
+require 'poker_hands/card'
+
+module PokerHands
+  class BuildCards
+    def call
+      ranks = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+      suits = ['C', 'H', 'S', 'D']
+      cards = []
+
+      ranks.each do |rank|
+        suits.each do |suit|
+          cards << Card.new(rank, suit)
+        end
+      end
+      return cards
+    end
+  end
+end

--- a/lib/poker_hands/deck.rb
+++ b/lib/poker_hands/deck.rb
@@ -1,18 +1,11 @@
-require 'poker_hands/card'
+require 'poker_hands/build_cards'
 
 module PokerHands
   class Deck
-    def initialize
-      @ranks = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
-      @suits = ['C', 'H', 'S', 'D']
-      @cards = []
+    attr_reader :cards
 
-      @ranks.each do |rank|
-        @suits.each do |suit|
-          @cards << Card.new(rank, suit)
-        end
-      end
-      @cards.shuffle!
+    def initialize
+      @cards = BuildCards.new.call()
     end
 
     def draw(card_count)

--- a/lib/poker_hands/game.rb
+++ b/lib/poker_hands/game.rb
@@ -4,15 +4,17 @@ require 'poker_hands/compare_hands'
 module PokerHands
   class Game
     def initialize
+
       deck = Deck.new
+      shuffled_deck = deck.shuffle
 
-      @hand1 = deck.draw(5)
-      @hand2 = deck.draw(5)
+      hand1 = shuffled_deck.draw(5)
+      hand2 = shuffled_deck.draw(5)
 
-      winning_message = CompareHands.new.call(@hand1, @hand2)
+      winning_message = CompareHands.new.call(hand1, hand2)
       
-      puts "Hand 1: [#{@hand1.join(', ')}]"
-      puts "Hand 2: [#{@hand2.join(', ')}]"
+      puts "Hand 1: [#{hand1.join(', ')}]"
+      puts "Hand 2: [#{hand2.join(', ')}]"
       puts "\n#{winning_message}"
     end
   end

--- a/spec/build_cards_spec.rb
+++ b/spec/build_cards_spec.rb
@@ -1,0 +1,13 @@
+require 'poker_hands/build_cards'
+require 'spec_helper'
+
+
+RSpec.describe PokerHands::BuildCards do
+  subject { PokerHands::BuildCards.new.call() }
+
+  context 'builds cards' do
+    it 'produces Card objects' do
+      expect(subject).to all(be_a(PokerHands::Card))
+    end
+  end
+end

--- a/spec/deck_spec.rb
+++ b/spec/deck_spec.rb
@@ -1,0 +1,30 @@
+require 'poker_hands/deck'
+require 'spec_helper'
+
+
+RSpec.describe PokerHands::Deck do
+  subject { PokerHands::Deck.new() }
+
+  context 'a Deck' do
+    it 'contains 52 Card objects' do
+      expect(subject.cards.length).to be(52)
+      expect(subject.cards).to all(be_a(PokerHands::Card))
+    end
+  end
+
+  describe '#draw' do
+    context 'drawing two cards' do
+      let(:hand1) { subject.draw(2) }
+
+      it 'draws the ace of diamonds off the deck' do
+        expect(hand1[1].rank).to be(14)
+        expect(hand1[1].suit).to eq('D')
+      end
+
+      it 'draws the ace of spades off the deck' do
+        expect(hand1[0].rank).to be(14)
+        expect(hand1[0].suit).to eq('S')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I created a BuildCards factory to handle the Card object building
business. Deck no longer knows how to build Card objects because
of this. I also included a spec for BuildCards.