### PR TITLE
Add Spec for ClassifyHand

### DIFF
--- a/spec/classify_hands_spec.rb
+++ b/spec/classify_hands_spec.rb
@@ -1,0 +1,23 @@
+require 'poker_hands/hand_rankings/find_three_of_a_kind'
+require 'poker_hands/classify_hand'
+require 'spec_helper'
+
+RSpec.describe PokerHands::ClassifyHand do
+  subject { PokerHands::ClassifyHand.new.call(hand) }
+
+  context 'given a three of a kind poker hand' do
+    let(:hand) do
+      [
+        PokerHands::Card.new(4, 'H'),
+        PokerHands::Card.new(4, 'S'),
+        PokerHands::Card.new(8, 'S'),
+        PokerHands::Card.new(4, 'D'),
+        PokerHands::Card.new(9, 'S')
+      ]
+    end
+
+    it 'classifies the hand' do
+      expect(subject).to be_a(PokerHands::Entities::ThreeOfAKind)
+    end
+  end
+end


### PR DESCRIPTION
We test that the proper entity is returned when given a three of a kind
because the Class would be required to skip over nil entries in the
found_hands array and classify the best poker hand. By testing a poker
hand in the middle, we show that this is happening.